### PR TITLE
added bower to package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "gadget to checkin pages from all sites",
   "main": "gulpfile.js",
   "dependencies": {
-    "gulp-concat": "~2.6.0",
+    "bower": "^1.7.9",
     "gulp": "~3.9.1",
+    "gulp-concat": "~2.6.0",
     "gulp-minify-css": "~1.2.4",
     "gulp-rename": "~1.2.2",
     "gulp-sass": "~2.2.0",


### PR DESCRIPTION
for some reason this was missing, and never noticed since I have it installed globally on all my dev machines. when I pushed to production and attempted to build on site, I then ran into this problem. probably won't ever be an issue since most folks zip up build dir and deploy, but I heavily use git for deploy and this just makes sense in the dependencies.

side note: I added it to the regular dependencies, despite the fact it should probably be a devDependency, because that's where all the gulp dependencies were so at least it's consistent. you might consider moving all those+bower to the devDependency block for semantics.